### PR TITLE
Added a file send option for the client (Option 4)

### DIFF
--- a/client/encrypt.py
+++ b/client/encrypt.py
@@ -1,0 +1,75 @@
+import base64
+from Crypto.Cipher import AES, PKCS1_OAEP
+from Crypto.PublicKey import RSA
+from Crypto.Random import get_random_bytes
+from cconnector import send_message, receive_message
+import json, os
+
+AES_KEY_SIZE = 32 #256 bits
+AES_NONCE_SIZE = 12 #96 bits
+
+def send_file(tls_socket):
+    data = b'encrypted data'
+    pubkey = ''
+    file_name = input("Please enter the name of the file you'd like to send: ")
+    # 1. Get public key
+    senddata = {
+        "action": "getpk",
+        "username": input("Enter the recipient you wish to send to: ")
+    }
+    message = json.dumps(senddata)
+    try:
+        send_message(tls_socket, message) 
+        response = receive_message(tls_socket, None)
+        message_r = json.loads(response)
+        pubkey = message_r['key']
+       # print(f"user's public key: '{pubkey}'")       #For testing
+    except Exception as e:
+        print(f"Error retrieving client's public key: '{e}'")
+        input("Returning to menu, press Enter to continue...")
+        os.system('cls' if os.name == 'nt' else 'clear')  # Clear the screen
+    except json.JSONDecodeError:
+            print("Invalid JSON format in response, please try again.")
+            return
+    # 2. Generate Session Key
+    session_key = get_random_bytes(AES_KEY_SIZE)
+    # 3. Create RSA cipher using recipients public key
+    rsa_key_obj = RSA.import_key(pubkey)
+    rsa_cipher = PKCS1_OAEP.new(rsa_key_obj)
+    encrypted_session_key = rsa_cipher.encrypt(session_key)
+    # 4. Use session key to encrypt file
+    aes_cipher = AES.new(session_key, AES.MODE_GCM)
+    nonce = aes_cipher.nonce
+    ciphertext, tag = aes_cipher.encrypt_and_digest(data)
+    # 5. Send the payload
+    payload = {
+        "action": "upload",
+        "file": file_name,
+        "nonce_b64": base64.b64encode(nonce).decode('utf-8'),
+        "encrypted_file_b64": base64.b64encode(ciphertext).decode('utf-8'),
+        "tag_b64": base64.b64encode(tag).decode('utf-8'), # Send tag separately for clarity at receiver
+        "encrypted_key_b64": base64.b64encode(encrypted_session_key).decode('utf-8')
+    }
+    message = json.dumps(payload)
+    try:
+        send_message(tls_socket, message)
+        response = receive_message(tls_socket, None)
+        if response is not None:
+            try:
+                data = json.loads(response)  # Parse incoming JSON message
+            except json.JSONDecodeError:
+                print("Invalid JSON format in response, please try again.")
+                return
+            # Print server response
+            if data["status"] == "ERROR":
+                print(f"\nRegistration failed: {data["message"]}")
+            elif data["status"] == "OK":
+                print(f"\n{data["message"]}")
+                # Save account details, send server public key
+            # Return to client menu
+            input("Returning to menu, press Enter to continue...")
+
+        os.system('cls' if os.name == 'nt' else 'clear')  # Clear the screen
+    except Exception as e:
+         print("Error in /client/encrypt.py")
+         

--- a/client/main.py
+++ b/client/main.py
@@ -7,10 +7,14 @@ from Crypto.PublicKey import RSA
 
 from keylogic import generate_key_pair, get_private, get_public
 from menuoptions import send_registration_request, send_login_request, send_exit_request
-
+from encrypt import send_file
 import json
 
 def main():
+    # Check if client key directory exists/make if not
+    if not os.path.isdir("./keys"):
+        os.makedirs("./keys")
+    # Check if both client keys can be retrieved, if not generate new keys and remove old keys if they exist
     # Check if client key directory exists/make if not
     if not os.path.isdir("./keys"):
         os.makedirs("./keys")
@@ -20,8 +24,7 @@ def main():
             os.remove("./keys/public.pem")
         if os.path.isfile("./keys/private.pem"):
             os.remove("./keys/private.pem")
-        
-        # Generate new pseudorandom password protected private RSA key and public RSA key
+    # Generate new pseudorandom password protected private RSA key and public RSA key
         if not generate_key_pair(SHA256.new(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f").encode()).hexdigest()[:16]):
             print("Key generation failed.")
             return
@@ -56,12 +59,13 @@ def main():
             while True:
                 # Display menu options to the user
                 option = 0
-                while option not in [1, 2, 3]:
+                while option not in [1, 2, 3, 4]:
                     try:
                         option = int(input("""Welcome to SFTP v1.0! Please register if this is your first time connecting, or login if you already have an account:
                           1. Register
                           2. Login
                           3. Exit
+                          4. Send file
                         """))
                     except ValueError:
                         print("Invalid input. Please enter a number between 1 and 3.")
@@ -73,11 +77,12 @@ def main():
                 # Login existing user
                 elif option == 2:
                     send_login_request(tls_socket_client)
-
                 # Exit the program
                 elif option == 3:
                     send_exit_request(tls_socket_client)
                     break
+                elif option == 4:
+                    send_file(tls_socket_client)
             ### MAIN CLIENT LOOP END ###
         except KeyboardInterrupt as e:
             try:

--- a/client/menuoptions.py
+++ b/client/menuoptions.py
@@ -1,18 +1,40 @@
+import datetime
 import json
 import time
 import os
 
+from Crypto.Hash import SHA256
 from cconnector import send_message, receive_message
+from keylogic import generate_key_pair
 
 # Send registration request to the server
 def send_registration_request(tls_socket):
+
+    if os.path.isfile("./keys/public.pem"):
+        os.remove("./keys/public.pem")
+        if os.path.isfile("./keys/private.pem"):
+            os.remove("./keys/private.pem")
+        
+        # Generate new pseudorandom password protected private RSA key and public RSA key
+    if not generate_key_pair(SHA256.new(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f").encode()).hexdigest()[:16]):
+        print("Key generation failed.")
+        return
+    public_key = './keys/public.pem'
+    try:
+        with open(public_key, 'r+') as key_file:
+            key_data = key_file.read()
+    except Exception as e:
+        print(f"Error opening public key file: '{e}'")
+
     """Send the registration request with user data to the server"""
     registration_data = {
         "action": "register",  # Action type
         "name": input("Enter your full name: "),
         "email": input("Enter your email address: "),
         "username": input("Choose a username: "),
-        "password": input("Choose a password (NOTE: must only contain alphanumberic characters and be 16 characters or longer): ")
+        "password": input("Choose a password (NOTE: must only contain alphanumberic characters and be 16 characters or longer): "),
+        "key": key_data
+        
     }
 
     try:
@@ -30,8 +52,15 @@ def send_registration_request(tls_socket):
                 print(f"\nRegistration failed: {data["message"]}")
             elif data["status"] == "OK":
                 print(f"\n{data["message"]}")
+            # Save account details, send server public key
+            try:    
+                with open("./client/client_account.json", 'w+') as jsonfile:
+                    json.dump(registration_data, jsonfile, indent=3)
+            except Exception as e:
+                print(f"Error writing client account data")
             # Return to client menu
             input("Returning to menu, press Enter to continue...")
+
             os.system('cls' if os.name == 'nt' else 'clear')  # Clear the screen
     except Exception as e:
         print(f"Error sending registration data: {e}")
@@ -53,6 +82,7 @@ def send_login_request(tls_socket):
         # Return to client menu
         input("Returning to menu, press Enter to continue...")
         os.system('cls' if os.name == 'nt' else 'clear')  # Clear the screen
+        send_public_key(tls_socket)
     except Exception as e:
         print(f"Error sending login data: {e}")
 
@@ -71,6 +101,34 @@ def send_exit_request(tls_socket):
             print("Invalid JSON format in response, please try again.")
             return
         # Return to main to terminate program
-        print(data["message"])
+        print(data["key"])
     except Exception as e:
         print(f"Error sending exit data: {e}")
+
+def send_public_key(tls_socket):
+    try:
+        with open('./client_account.json', 'r+') as jsonfile:
+            data = json.load(jsonfile)
+            if isinstance(data, dict) and 'name' in data:
+                name = data["name"]
+                print(name)
+    except Exception as e:
+        print(f"Error opening gathering account information: '{e}'")
+    public_key = './keys/public.pem'
+    try:
+        with open(public_key, 'r+') as key_file:
+            key_data = key_file.read()
+    except Exception as e:
+        print(f"Error opening public key file: '{e}'")
+    print(f"Public key: '{key_data}")
+    data = {
+        "action": "storepk",
+        "name": name, 
+        "key": key_data
+    }
+    message = json.dumps(data)
+    try:
+        send_message(tls_socket, message)
+    except Exception as e:
+        print(f"Error sending public key: {e}")
+    

--- a/server/handler.py
+++ b/server/handler.py
@@ -4,7 +4,7 @@ import logging
 import threading
 
 import json 
-from server_utils import register_user # Using utility function
+from server_utils import * # Using utility function
 from sconnector import send_message, receive_message
 
 # Program instance main function
@@ -51,6 +51,12 @@ def handle_client(ssl_client_socket: ssl.SSLSocket, client_address):
                         "message": "Have a nice day!"
                     }))
                     break
+                elif action == "storepk": #Save public key to share with other clients
+                    save_public_key(data)
+                elif action == "getpk":
+                    get_user_key(ssl_client_socket, data) 
+                elif action == "upload":
+                    upload_file(ssl_client_socket, data)
                 else:
                     send_message(ssl_client_socket, json.dumps({
                         "status": "ERROR",

--- a/server/server_utils.py
+++ b/server/server_utils.py
@@ -28,7 +28,7 @@ def user_exists(username):
     users = load_users()["users"]
     return any(user["username"] == username for user in users)
 
-def create_user(name, email, username, password):
+def create_user(name, email, username, password, key):
     """Create a new user account and store it in the JSON file"""
     if user_exists(username):
         return {"status": "ERROR", "message": "Username is already taken."}
@@ -40,6 +40,7 @@ def create_user(name, email, username, password):
         "password": hash_password(password),  # Store hashed password
         "online": False,  # New users are offline by default
         "friends": [],  # New users have no friends by default
+        "key": key,
     }
     
     data = load_users()
@@ -55,7 +56,7 @@ def create_user(name, email, username, password):
 def register_user(ssl_client_socket, data):
     print(f"Received registration data: {data}")
     # Check if all required fields are present and valid
-    required_fields = ["name", "email", "username", "password"]
+    required_fields = ["name", "email", "username", "password", "key"]
     if any(not data[field] for field in required_fields):
         send_message(ssl_client_socket, json.dumps({
             "status": "ERROR",
@@ -73,6 +74,80 @@ def register_user(ssl_client_socket, data):
             data["name"],
             data["email"],
             data["username"],
-            data["password"]
+            data["password"],
+            data["key"]
         )
         send_message(ssl_client_socket, json.dumps(result))
+def get_user_key(ssl_client_socket, data):
+    print(f"Received request for public key")
+    name = data["username"]
+    print(f"username to find: '{name}'")
+    with open(DATA_FILE, 'r') as keystore:     # Open JSON file of accounts
+        try:
+            user_data = json.load(keystore)
+            user_list = user_data.get("users")  # Iterate through "users"
+            if isinstance(user_list, list):
+                for user in user_list:
+                    if isinstance(user, dict) and user.get("username") == name: #find matching user, copy and send public key 
+                        public_key = user.get("key")
+                        send_message(ssl_client_socket, json.dumps({"key": public_key}))
+        except Exception as e:
+            print(f"Error retrieving user key")
+            send_message(ssl_client_socket, json.dumps({
+            "status": "ERROR",
+            "message": "Error retrieving public key"
+        }))
+# Process and save client uploaded files
+def upload_file(ssl_client_socket, data):
+    base_dir = './server/files/'
+    os.makedirs(base_dir, exist_ok=1) # Ensure directory is available to store client files
+    print("Server converted to JSON, JSON file: \n\n")
+    print(data)
+    # Get file name
+    file = data["file"]
+    file_name = file+".json"
+    print(f"File name {file_name}")
+    filepath = os.path.join(base_dir, file_name)
+    if not file or not isinstance(file, str):
+             raise ValueError("Missing or invalid 'file' name in received data.")
+    print(f"Attempting to open '{file}'")
+    data = json.dumps(data)
+    try:
+        with open(filepath, 'w') as f:
+            f.write(data)  # Saving the uploaded file to server storage
+            send_message(ssl_client_socket, json.dumps({
+            "status": "OK",
+            "message": "Server successfully uploaded file"
+        }))
+    except IOError as e:
+        print(f"IO Error writing message file {file}: {e}")
+    except Exception as e:
+        send_message(ssl_client_socket, json.dumps({
+            "status": "ERROR",
+            "message": "ERROR uploading file"
+            }))
+
+
+# Function for user to save a public key to their account
+def save_public_key(user_data):
+    name = user_data["name"]
+    key = user_data["key"]
+    data = []
+    # Find user and write key to file
+    print(f"Storing public key to record")
+    try:
+        with open(DATA_FILE, "r+") as jsonfileR:
+            data = json.load(jsonfileR)
+            for user in data:
+                if isinstance(user, dict) and user.get("name") == name:
+                    user["key"] = key
+                    break
+    except Exception as e:
+        print(f"Error opening record: '{e}'")
+    try:
+        with open(DATA_FILE, "w") as jsonfileW:
+            json.dump(data, jsonfileW, indent=3)
+            print(f"Public key processed for '{name}")
+    except Exception as e:
+        print(f"Error saving updated record: '{e}")
+


### PR DESCRIPTION
Added the public key to be sent during registration. Server can easily record an pull an entire account.
Registration now saves a local account record for client self-reference Currently referenced by Send key function

Send key was added to menuoptions, since that is where most client handler functions are. Function is currently called on Login, in case a new key pair needed to be generated on start. Can be moved as needed.

Encrytion function uses RSA + AES of a static string Encrypt function contains logic for requesting a user's public key. For testing purposes, any key matching username is returned. Intended for registered friends.

Server handler added action cases for:
1. storepk: Saving a public key (not called yet, for regenerated keys)
2. getpk: Sends user key information
3. upload: Uploading encrypted file

server utils added functions for these cases.

-------------------TODO--------------------------
*Add file reader to encrypt function (client)
*Add friends feature (client)
    *Verify friends (server) using send_pk(client)
*Download file
    *Request download (client)
    *Send file (server)
    *Save file locally (client)
    *Notify sender of download (server)

! Both server and client are storing files outside of respective dir. ! Fix when packaging file/server

? Server encrypt file before storing, decrypt before transmitting ? More robust response for client
? Ensure different filetypes work